### PR TITLE
graphic/pssl/parser: Fix VOP{2,3,C} OP decoding

### DIFF
--- a/GPCS4/Graphic/Pssl/GCNParser/ParserSIVOP.cpp
+++ b/GPCS4/Graphic/Pssl/GCNParser/ParserSIVOP.cpp
@@ -172,8 +172,8 @@ ParserSI::kaStatus ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::inst
         }
         else if (VOPInstruction::Encoding_VOP2 == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
-            hexInstTem = hexInstTem >> 24;
+            uint64_t hexInstTem = hexInstruction << 1;
+            hexInstTem = hexInstTem >> 26;
             SIVOP2Instruction::VOP2_OP op2 = static_cast<SIVOP2Instruction::VOP2_OP>(hexInstTem);
 			unsigned int vidx1 = 0 ,vdstRidx = 0;;
 			VOPInstruction::VSRC vsrc1 = GetVSRC1(hexInstruction, vidx1);
@@ -188,7 +188,7 @@ ParserSI::kaStatus ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::inst
 
         else if (VOPInstruction::Encoding_VOPC == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
+            uint64_t hexInstTem = hexInstruction << 7;
             hexInstTem = hexInstTem >> 24;
             SIVOPCInstruction::VOPC_OP opc = static_cast<SIVOPCInstruction::VOPC_OP>(hexInstTem);
 			unsigned int vidx1 = 0;
@@ -211,8 +211,8 @@ ParserSI::kaStatus ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::inst
         }
         else if (VOPInstruction::Encoding_VOP2 == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
-            hexInstTem = hexInstTem >> 24;
+            uint64_t hexInstTem = hexInstruction << 1;
+            hexInstTem = hexInstTem >> 26;
             VIVOP2Instruction::VOP2_OP op2 = static_cast<VIVOP2Instruction::VOP2_OP>(hexInstTem);
 			// TODO:
 			// Not sure if there's some special opcode which use literal const while src != SRCLiteralConst
@@ -223,7 +223,7 @@ ParserSI::kaStatus ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::inst
 
         else if (VOPInstruction::Encoding_VOPC == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
+            uint64_t hexInstTem = hexInstruction << 7;
             hexInstTem = hexInstTem >> 24;
             VIVOPCInstruction::VOPC_OP opc = static_cast<VIVOPCInstruction::VOPC_OP>(hexInstTem);
 			hasLiteral = (src0 == VIVOPCInstruction::SRCLiteralConst);
@@ -244,8 +244,8 @@ ParserSI::kaStatus ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::inst
         }
         else if (VOPInstruction::Encoding_VOP2 == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
-            hexInstTem = hexInstTem >> 24;
+            uint64_t hexInstTem = hexInstruction << 1;
+            hexInstTem = hexInstTem >> 26;
             G9VOP2Instruction::VOP2_OP op2 = static_cast<G9VOP2Instruction::VOP2_OP>(hexInstTem);
 			// TODO:
 			// Not sure if there's some special opcode which use literal const while src != SRCLiteralConst
@@ -256,7 +256,7 @@ ParserSI::kaStatus ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::inst
 
         else if (VOPInstruction::Encoding_VOPC == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
+            uint64_t hexInstTem = hexInstruction << 7;
             hexInstTem = hexInstTem >> 24;
             VIVOPCInstruction::VOPC_OP opc = static_cast<VIVOPCInstruction::VOPC_OP>(hexInstTem);
 			hasLiteral = (src0 == VIVOPCInstruction::SRCLiteralConst);
@@ -285,8 +285,8 @@ ParserSIVOP::Parse(GDT_HW_GENERATION hwGen, Instruction::instruction64bit hexIns
     {
         if (VOPInstruction::Encoding_VOP3 == encoding)
         {
-            uint64_t hexInstTem = hexInstruction << 15;
-            hexInstTem = hexInstTem >> 24;
+            uint64_t hexInstTem = hexInstruction << 6;
+            hexInstTem = hexInstTem >> 22;
             SIVOP3Instruction::VOP3_OP op3 = static_cast<SIVOP3Instruction::VOP3_OP>(hexInstTem);
 
 			unsigned int ridx1 = 0, ridx2 = 0;


### PR DESCRIPTION
- Only Southerm Islands tested & guaranteed to be correct, the others are guessed based on it.
- VOP3 change is untested but it's similar and it should work.

---
Btw, I'm working on a shader (re)compiler based on your code (the `GCNCompiler` class).
Its code is clean and based on your style and existing `GCNParser`/Pssl code. It's at an early stage but can compile some basic shaders.

If you'd like to collaborate on it, or just exchange ideas (2 minds are better than one 😃), feel free to message me on Discord (`velocity#4995`) or via email (it's on my GitHub profile).

The compiler is a lot of work, there are many tedious parts and I'd rather not duplicate effort for no reason. Probably better if we can work on it together. I can share the code that I have currently, if you want to take a look.

Either way, I'll probably continue pushing such bugfixes here that you may find useful.