### PR TITLE
libkernel: Implement _write for standard output streams. linker: Few logging fixes

### DIFF
--- a/GPCS4/Emulator/Linker.cpp
+++ b/GPCS4/Emulator/Linker.cpp
@@ -96,7 +96,7 @@ bool CLinker::resolveSymbol(MemoryMappedModule const &mod,
 			{
 				// NOTE: Something is wrong with va_args and u64 values, so print NID as 2 u32
 				formatString =
-					"Unknown Function nid 0x%08x%08x from lib:%s is called: 0x%08x";
+					"Unknown Function nid 0x%08x%08x (\"%s\") from lib:%s is called at 0x%08x";
 			}
 			else
 			{
@@ -104,9 +104,12 @@ bool CLinker::resolveSymbol(MemoryMappedModule const &mod,
 					"Function nid 0x%08x%08x from lib:%s is called";
 			}
 
+			auto nidString = info->symbolName.substr(0, 11);
+
 			auto msg = UtilString::Format(formatString,
 										  info->nid >> 32,
 										  info->nid,
+										  nidString.c_str(),
 										  info->libraryName.c_str());
 
 			auto stubMgr  = GetFuncStubManager();

--- a/GPCS4/Emulator/Linker.cpp
+++ b/GPCS4/Emulator/Linker.cpp
@@ -94,16 +94,18 @@ bool CLinker::resolveSymbol(MemoryMappedModule const &mod,
 
 			if (address == nullptr)
 			{
+				// NOTE: Something is wrong with va_args and u64 values, so print NID as 2 u32
 				formatString =
-					"Unknown Function nid 0x%016x from lib:%s is called: 0x%08x";
+					"Unknown Function nid 0x%08x%08x from lib:%s is called: 0x%08x";
 			}
 			else
 			{
 				formatString =
-					"Function nid 0x%016x from lib:%s is called";
+					"Function nid 0x%08x%08x from lib:%s is called";
 			}
 
 			auto msg = UtilString::Format(formatString,
+										  info->nid >> 32,
 										  info->nid,
 										  info->libraryName.c_str());
 

--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_file.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_file.cpp
@@ -4,6 +4,7 @@
 #include "Platform/UtilPath.h"
 #include <io.h>
 #include <fcntl.h>
+#include <cstdio>
 
 // this will be more friendly on linux....
 
@@ -65,6 +66,26 @@ inline bool getDirName(DIR* dir, char* dirname, int len)
 }
 
 #endif  //GPCS4_WINDOWS
+
+
+int PS4API scek__write(int fd, const void* buf, size_t size)
+{
+	LOG_SCE_TRACE("fd %d buf 0x%p size %zu", fd, buf, size);
+
+	_write(fd, buf, size);
+
+	// If it's stdout/stderr, also log it to emulator logger
+	if (fd == 1 || fd == 2)
+	{
+		// TODO: Strip newline, log line already adds one
+		std::string tempBuf(static_cast<const char*>(buf), 0, size);
+		tempBuf.append("\0"); // buf is not guaranteed to be null-terminated, so append null terminator after 'size' chars
+		LOG_TRACE("%s", tempBuf.c_str());
+	}
+
+	return size;
+}
+
 
 int PS4API sceKernelOpen(const char *path, int flags, SceKernelMode mode)
 {

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel.cpp
@@ -264,13 +264,12 @@ int PS4API scek_getpid(void)
 }
 
 
-int PS4API scek_getppid(void) 
+int PS4API scek_getppid(void)
 {
 	int pid = 0x1;
 	LOG_SCE_TRACE("return %d", pid);
 	return pid;
 }
-
 
 
 

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
@@ -47,6 +47,9 @@ int PS4API __tls_get_addr(void);
 int PS4API __pthread_cxa_finalize(void);
 
 
+int PS4API scek__write(int fd, const void* buf, size_t size);
+
+
 int PS4API sceKernelAllocateDirectMemory(sceoff_t searchStart, sceoff_t searchEnd, size_t len, size_t alignment, int memoryType, sceoff_t *physAddrOut);
 
 
@@ -522,8 +525,6 @@ int PS4API scek_getpid(void);
 
 
 int PS4API scek_getppid(void);
-
-
 
 
 

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel_export.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel_export.cpp
@@ -13,6 +13,7 @@ static const SCE_EXPORT_FUNCTION g_pSceLibkernel_libkernel_FunctionTable[] =
 	{ 0x7FBB8EC58F663355, "__stack_chk_guard", (void*)__stack_chk_guard },
 	{ 0xBCD7B5C387622C2B, "__tls_get_addr", (void*)__tls_get_addr },
 	{ 0x91BC385071D2632D, "__pthread_cxa_finalize", (void*)__pthread_cxa_finalize },
+	{ 0x171559A81000EE4B, "_write", (void*)scek__write },
 	{ 0xAD35F0EB9C662C80, "sceKernelAllocateDirectMemory", (void*)sceKernelAllocateDirectMemory },
 	{ 0x4018BB1C22B4DE1C, "sceKernelClockGettime", (void*)sceKernelClockGettime },
 	{ 0x50AD939760D6527B, "sceKernelClose", (void*)sceKernelClose },


### PR DESCRIPTION
Guest "printf", etc output now gets logged.

Also:
- Fix logging of unknown function call NIDs
- Log base64 form of NID on unknown calls