### PR TITLE
msvc: Fix IntelliSense errors

### DIFF
--- a/GPCS4/Common/MacroHelper.h
+++ b/GPCS4/Common/MacroHelper.h
@@ -16,4 +16,6 @@
 // maybe relative to the garlic memory base address.
 #define GNM_GPU_ABS_ADDR(refAddr, relaAddr) ( (void*)(((uint64_t)(refAddr) & 0x0000FF0000000000) | uint64_t(relaAddr)) )
 
-
+// There is __INTELLISENSE__, but it does not appear to work correctly with the clang frontend,
+// so use this workaround instead (which works because Intellisense won't have __clang__ set).
+#define IS_INTELLISENSE !defined(__clang__) && !defined(__GNUC__)

--- a/GPCS4/GPCS4Common.h
+++ b/GPCS4/GPCS4Common.h
@@ -7,6 +7,16 @@
 #include "Common/ReferenceCount.h"
 
 
+// Prevent Intellisense throwing errors due to not understanding "__attribute__" (clang-specific directive)
+#if IS_INTELLISENSE
+#define PS4API
+#define PS4NORETURN
+#define PS4NAKED
+#define PS4NOINLINE
+#define PS4DEPRECATED
+#define PS4UNUSED
+#define PS4ALIGN
+#else
 #define PS4API __attribute__((sysv_abi))
 
 #define PS4NORETURN __attribute__((noreturn))
@@ -20,3 +30,4 @@
 #define PS4UNUSED __attribute__((unused))
 
 #define PS4ALIGN(n) __attribute__((__aligned__(n)))
+#endif


### PR DESCRIPTION
Refresh the VS program database and the project should show no annoying IntelliSense errors now.