### PR TITLE
Loader bug fix

### DIFF
--- a/GPCS4/Loader/ModuleLoader.cpp
+++ b/GPCS4/Loader/ModuleLoader.cpp
@@ -183,10 +183,8 @@ bool ModuleLoader::loadDependencies()
 			{
 				retVal = true;
 			}
-			else
-			{
-				break;
-			}
+
+			break;
 		}
 
 		if (!exist)
@@ -198,6 +196,7 @@ bool ModuleLoader::loadDependencies()
 				break;
 			}
 		}
+		retVal = true;
 	}
 
 	return retVal;


### PR DESCRIPTION
Fix a bug in loader that causes not-found modules to be registered to the module system due to improper error handling.