### PR TITLE
Remove redundant if() check

### DIFF
--- a/GPCS4/Emulator/Module.cpp
+++ b/GPCS4/Emulator/Module.cpp
@@ -304,11 +304,7 @@ bool MemoryMappedModule::decodeSymbol(std::string const &strEncName,
 bool MemoryMappedModule::isEncodedSymbol(std::string const &symbolName) const
 {
 	bool retVal = false;
-	if (symbolName.length() != 15)
-	{
-		retVal = false;
-	}
-	else if (symbolName[11] != '#' || symbolName[13] != '#')
+	if (symbolName[11] != '#' || symbolName[13] != '#')
 	{
 		retVal = false;
 	}


### PR DESCRIPTION
It doesn't matter if symbolName.length() is equal to 15 or not, retVal remains unaffected.