### PR TITLE
Fix assert in sceKernelOpen so that it only fires when a currently unsupported mode is set

### DIFF
--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_file.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_file.cpp
@@ -118,7 +118,7 @@ int PS4API sceKernelOpen(const char *path, int flags, SceKernelMode mode)
 	else
 	{
 		LOG_ASSERT((flags == SCE_KERNEL_O_RDONLY), "not supported flag.");
-		LOG_ASSERT((mode == SCE_KERNEL_S_IRU), "not supported mode.");
+		LOG_ASSERT((mode == SCE_KERNEL_S_IRU) || ((mode == SCE_KERNEL_S_INONE) && ((flags & SCE_KERNEL_O_CREAT) == 0)), "not supported mode.");
 
 		int fd = _open(pcPath.c_str(), _O_RDONLY | _O_BINARY, _S_IREAD);
 		if (fd == -1)

--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_file.h
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_file.h
@@ -38,6 +38,8 @@ typedef uint16_t SceKernelMode;
 #define	SCE_S_ISVTX	 0001000		/* save swapped text even after use */
 
 // open mode
+#define SCE_KERNEL_S_INONE         0
+
 #define SCE_KERNEL_S_IRUSR         (SCE_S_IRUSR | SCE_S_IRGRP | SCE_S_IROTH | SCE_S_IXUSR | \
 									SCE_S_IXGRP | SCE_S_IXOTH)
 #define SCE_KERNEL_S_IWUSR         (SCE_S_IWUSR | SCE_S_IWGRP | SCE_S_IWOTH | SCE_S_IXUSR | \
@@ -48,8 +50,6 @@ typedef uint16_t SceKernelMode;
 #define SCE_KERNEL_S_IRWU          (SCE_KERNEL_S_IRUSR | SCE_KERNEL_S_IWUSR)
 // read
 #define SCE_KERNEL_S_IRU           (SCE_KERNEL_S_IRUSR)
-
-#define SCE_KERNEL_S_INONE         0
 
 #define SCE_KERNEL_S_IFMT          SCE_S_IFMT
 #define SCE_KERNEL_S_IFDIR         SCE_S_IFDIR

--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_file.h
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_file.h
@@ -49,6 +49,8 @@ typedef uint16_t SceKernelMode;
 // read
 #define SCE_KERNEL_S_IRU           (SCE_KERNEL_S_IRUSR)
 
+#define SCE_KERNEL_S_INONE         0
+
 #define SCE_KERNEL_S_IFMT          SCE_S_IFMT
 #define SCE_KERNEL_S_IFDIR         SCE_S_IFDIR
 #define SCE_KERNEL_S_IFREG         SCE_S_IFREG

--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_pthread.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_pthread.cpp
@@ -91,22 +91,7 @@ int PS4API scek_pthread_join(void)
 int PS4API scek_pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
 {
 	LOG_SCE_TRACE("mutex %p attr %p", mutex, attr);
-	auto ret = 0;
-	if (attr == nullptr)
-	{
-		// If attr is nullptr then default will be used which is PTHREAD_MUTEX_ERRORCHECK on PS4
-		// so we make sure we set PTHREAD_MUTEX_ERRORCHECK here to match behaviour.
-		pthread_mutexattr_t errorCheckMutexAttr;
-		pthread_mutexattr_init(&errorCheckMutexAttr);
-		pthread_mutexattr_settype(&errorCheckMutexAttr, PTHREAD_MUTEX_ERRORCHECK);
-		ret = pthread_mutex_init((pthread_mutex_t*)mutex, &errorCheckMutexAttr);
-		pthread_mutexattr_destroy(&errorCheckMutexAttr);
-	}
-	else
-	{
-		ret = pthread_mutex_init(mutex, attr);
-	}
-	return ret;
+	return scePthreadMutexInit(mutex, attr, nullptr);
 }
 
 

--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_scepthread.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_scepthread.cpp
@@ -152,7 +152,21 @@ int PS4API scePthreadMutexInit(ScePthreadMutex *mutex, const ScePthreadMutexattr
 	{
 		LOG_FIXME("set name is not supported yet.")
 	}
-	int err = pthread_mutex_init((pthread_mutex_t*)mutex, (pthread_mutexattr_t*)attr);
+	int err = 0;
+	if (attr == nullptr)
+	{
+		// If attr is nullptr then default will be used which is PTHREAD_MUTEX_ERRORCHECK on PS4
+		// so we make sure we set PTHREAD_MUTEX_ERRORCHECK here to match behaviour.
+		pthread_mutexattr_t errorCheckMutexAttr;
+		pthread_mutexattr_init(&errorCheckMutexAttr);
+		pthread_mutexattr_settype(&errorCheckMutexAttr, PTHREAD_MUTEX_ERRORCHECK);
+		err = pthread_mutex_init((pthread_mutex_t*)mutex, &errorCheckMutexAttr);
+		pthread_mutexattr_destroy(&errorCheckMutexAttr);
+	}
+	else
+	{
+		err = pthread_mutex_init((pthread_mutex_t*)mutex, (pthread_mutexattr_t*)attr);
+	}
 	return pthreadErrorToSceError(err);
 }
 

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
@@ -529,10 +529,10 @@ int PS4API scek_pthread_mutex_unlock(pthread_mutex_t* mtx);
 int PS4API scek_pthread_mutexattr_destroy(void);
 
 
-int PS4API scek_pthread_mutexattr_init(void);
+int PS4API scek_pthread_mutexattr_init(pthread_mutexattr_t * attr);
 
 
-int PS4API scek_pthread_mutexattr_settype(void);
+int PS4API scek_pthread_mutexattr_settype(pthread_mutexattr_t* attr, int type);
 
 
 ScePthread PS4API scek_pthread_self(void);


### PR DESCRIPTION
Fixes the "not supported mode" assert in sceKernelOpen which currently incorrectly fires when a mode of SCE_KERNEL_S_INONE is passed in. SCE_KERNEL_S_INONE can be ignored unless SCE_KERNEL_O_CREAT is set in flags.