### PR TITLE
Fix some pthread functions

### DIFF
--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_pthread.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_pthread.cpp
@@ -5,7 +5,7 @@
 
 LOG_CHANNEL(SceModules.SceLibkernel.pthread);
 
-int pthreadErrorToSceError(int perror);
+int sceMutexAttrTypeToPthreadType(int type);
 
 int PS4API scek_pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
 {
@@ -90,8 +90,21 @@ int PS4API scek_pthread_join(void)
 //////////////////////////////////////////////////////////////////////////
 int PS4API scek_pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
 {
-	LOG_SCE_TRACE("mutex %p attr %p", mutex, attr);
-	auto ret =  pthread_mutex_init(mutex, attr);
+	auto ret = 0;
+	if (attr == nullptr)
+	{
+		// If attr is nullptr then default will be used which is PTHREAD_MUTEX_ERRORCHECK on PS4
+		// so we make sure we set PTHREAD_MUTEX_ERRORCHECK here to match behaviour.
+		pthread_mutexattr_t errorCheckMutexAttr;
+		pthread_mutexattr_init(&errorCheckMutexAttr);
+		pthread_mutexattr_settype(&errorCheckMutexAttr, PTHREAD_MUTEX_ERRORCHECK);
+		ret = pthread_mutex_init((pthread_mutex_t*)mutex, &errorCheckMutexAttr);
+		pthread_mutexattr_destroy(&errorCheckMutexAttr);
+	}
+	else
+	{
+		ret = pthread_mutex_init(mutex, attr);
+	}
 	return ret;
 }
 
@@ -135,17 +148,20 @@ int PS4API scek_pthread_mutexattr_destroy(void)
 }
 
 
-int PS4API scek_pthread_mutexattr_init(void)
+int PS4API scek_pthread_mutexattr_init(pthread_mutexattr_t * attr)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	LOG_SCE_TRACE("attr %p", attr);
+	int err = pthread_mutexattr_init(attr);
+	return err;
 }
 
 
-int PS4API scek_pthread_mutexattr_settype(void)
+int PS4API scek_pthread_mutexattr_settype(pthread_mutexattr_t* attr, int type)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	LOG_SCE_TRACE("attr %p type %d", attr, type);
+	int ptype = sceMutexAttrTypeToPthreadType(type);
+	int err = pthread_mutexattr_settype((pthread_mutexattr_t*)attr, ptype);
+	return err;
 }
 
 // For PS4 system, ScePthread and pthread_t are same.

--- a/GPCS4/SceModules/SceLibkernel/sce_kernel_scepthread.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_kernel_scepthread.cpp
@@ -152,7 +152,21 @@ int PS4API scePthreadMutexInit(ScePthreadMutex *mutex, const ScePthreadMutexattr
 	{
 		LOG_FIXME("set name is not supported yet.")
 	}
-	int err = pthread_mutex_init((pthread_mutex_t*)mutex, (pthread_mutexattr_t*)attr);
+	int err = 0;
+	if (attr == nullptr)
+	{
+		// If attr is nullptr then default will be used which is PTHREAD_MUTEX_ERRORCHECK on PS4
+		// so we make sure we set PTHREAD_MUTEX_ERRORCHECK here to match behaviour.
+		pthread_mutexattr_t errorCheckMutexAttr;
+		pthread_mutexattr_init(&errorCheckMutexAttr);
+		pthread_mutexattr_settype(&errorCheckMutexAttr, PTHREAD_MUTEX_ERRORCHECK);
+		err = pthread_mutex_init((pthread_mutex_t*)mutex, &errorCheckMutexAttr);
+		pthread_mutexattr_destroy(&errorCheckMutexAttr);
+	}
+	else
+	{
+		err = pthread_mutex_init((pthread_mutex_t*)mutex, (pthread_mutexattr_t*)attr);
+	}
 	return pthreadErrorToSceError(err);
 }
 

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
@@ -529,10 +529,10 @@ int PS4API scek_pthread_mutex_unlock(pthread_mutex_t* mtx);
 int PS4API scek_pthread_mutexattr_destroy(void);
 
 
-int PS4API scek_pthread_mutexattr_init(void);
+int PS4API scek_pthread_mutexattr_init(pthread_mutexattr_t * attr);
 
 
-int PS4API scek_pthread_mutexattr_settype(void);
+int PS4API scek_pthread_mutexattr_settype(pthread_mutexattr_t* attr, int type);
 
 
 ScePthread PS4API scek_pthread_self(void);


### PR DESCRIPTION
Make scePthreadMutexInit and scek_pthread_mutex_init use correct default PTHREAD_MUTEX_ERRORCHECK behaviour when null mutex attr pointer is passed and implement scek_pthread_mutexattr_init and scek_pthread_mutexattr_settype

These changes make it so when a null mutex attr pointer is passed the mutex gets set up with PTHREAD_MUTEX_ERRORCHECK. This fixes a problem when loading Downwell where it hangs when locking an already locked mutex.  