### PR TITLE
Fixes to get some games to boot further

### DIFF
--- a/GPCS4/Emulator/RegisterModules.cpp
+++ b/GPCS4/Emulator/RegisterModules.cpp
@@ -37,7 +37,14 @@ static bool registerLibC(CSceModuleSystem* pModuleSystem)
 			.declareSubLibrary("libc").with(Policy::UseNative).except
 			({ 
 				0xC5E60EE2EEEEC89DULL, // fopen
-				0xAD0155057A7F0B18ULL, // fssek
+				0xAD0155057A7F0B18ULL, // fseek
+				0x40C1722E8A8DC488ULL, // setvbuf
+				0x48796DEC484EB6A0ULL, // fgetpos
+				0x2F170453E202BBC5ULL, // feof
+				0x004B85DC5D9FF130ULL, // fgetc
+				0x007C7284DF7A772EULL, // ferror
+				0x29D3FF9D42E9B86CULL, // fgets
+				0x8245A09F4A7501F5ULL, // freopen
 				0x41ACF2F0B9974EFCULL, // ftell
 				0x95B07E52566A546DULL, // fread
 				0xBA874B632522A76DULL, // fclose

--- a/GPCS4/SceModules/SceAudioOut/sce_audioout.cpp
+++ b/GPCS4/SceModules/SceAudioOut/sce_audioout.cpp
@@ -106,4 +106,10 @@ int PS4API sceAudioOutSetVolume(void)
 }
 
 
+int PS4API sceAudioOutInitIpmiGetSession(void)
+{
+	LOG_FIXME("Not implemented");
+	return SCE_OK;
+}
+
 

--- a/GPCS4/SceModules/SceAudioOut/sce_audioout.h
+++ b/GPCS4/SceModules/SceAudioOut/sce_audioout.h
@@ -58,3 +58,5 @@ int PS4API sceAudioOutOutputs(void);
 int PS4API sceAudioOutSetVolume(void);
 
 
+int PS4API sceAudioOutInitIpmiGetSession(void);
+

--- a/GPCS4/SceModules/SceAudioOut/sce_audioout_export.cpp
+++ b/GPCS4/SceModules/SceAudioOut/sce_audioout_export.cpp
@@ -15,6 +15,7 @@ static const SCE_EXPORT_FUNCTION g_pSceAudioOut_libSceAudioOut_FunctionTable[] =
 	{ 0x40E42D6DE0EAB13E, "sceAudioOutOutput", (void*)sceAudioOutOutput },
 	{ 0xC373DD6924D2C061, "sceAudioOutOutputs", (void*)sceAudioOutOutputs },
 	{ 0x6FEB8057CF489711, "sceAudioOutSetVolume", (void*)sceAudioOutSetVolume },
+	{ 0x9f5e8a768c67be5d, "sceAudioOutInitIpmiGetSession", (void*)sceAudioOutInitIpmiGetSession },
 	SCE_FUNCTION_ENTRY_END
 };
 

--- a/GPCS4/SceModules/SceLibc/sce_libc.h
+++ b/GPCS4/SceModules/SceLibc/sce_libc.h
@@ -144,9 +144,9 @@ float PS4API scec_expf(float x);
 
 int PS4API scec_fclose(FILE *stream);
 
-int PS4API scec_feof(void);
+int PS4API scec_feof(FILE * stream);
 
-int PS4API scec_fgetc(void);
+int PS4API scec_fgetc(FILE* stream);
 
 int PS4API scec_fmod(void);
 
@@ -161,6 +161,8 @@ int PS4API scec_fputc(int c, FILE *stream);
 int PS4API scec_fputs(void);
 
 size_t PS4API scec_fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+
+int PS4API scec_fgetpos(FILE* stream, fpos_t* pos);
 
 void PS4API scec_free(void *ptr);
 
@@ -342,13 +344,13 @@ int PS4API scec__ZSt11_Xbad_allocv(void);
 
 int PS4API scec__ZSt7nothrow(void);
 
-int PS4API scec_ferror(void);
+int PS4API scec_ferror(FILE* stream);
 
 int PS4API scec_fflush(void);
 
-int PS4API scec_fgets(void);
+char* PS4API scec_fgets(char* str, int num, FILE * stream);
 
-int PS4API scec_freopen(void);
+FILE* PS4API scec_freopen(const char * filename, const char * mode, FILE * stream);
 
 int PS4API scec_getc(void);
 

--- a/GPCS4/SceModules/SceLibc/sce_libc_export.cpp
+++ b/GPCS4/SceModules/SceLibc/sce_libc_export.cpp
@@ -186,6 +186,7 @@ static const SCE_EXPORT_FUNCTION g_pSceLibc_libc_FunctionTable[] =
 	{ 0x0C31C6D5AEBEDEAD, "roundf", (void*)scec_roundf },
 	{ 0x5CA45E82C1691299, "catchReturnFromMain", (void*)scec___catchReturnFromMain },
 	{ 0xD97E5A8058CAC4C7, "calloc", (void*)scec_calloc },
+	{ 0x48796DEC484EB6A0, "fgetpos", (void*)scec_fgetpos },
 	SCE_FUNCTION_ENTRY_END
 };
 

--- a/GPCS4/SceModules/SceLibc/sce_libc_file.cpp
+++ b/GPCS4/SceModules/SceLibc/sce_libc_file.cpp
@@ -23,6 +23,12 @@ size_t PS4API scec_fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 	return fread(ptr, size, nmemb, stream);
 }
 
+int PS4API scec_fgetpos( FILE* stream, fpos_t* pos )
+{
+	LOG_SCE_TRACE("fp %p pos %p", stream, pos);
+	return fgetpos(stream, pos);
+}
+
 
 size_t PS4API scec_fwrite(const void *ptr, size_t size, size_t nmemb, FILE* stream)
 {
@@ -42,21 +48,31 @@ long PS4API scec_ftell(FILE *stream)
 int PS4API scec_fclose(FILE *stream)
 {
 	LOG_SCE_TRACE("fp %p", stream);
-	return fclose(stream);
+	int ret = 0;
+	do
+	{
+		if (stream == nullptr)
+		{
+			break;
+		}
+
+		ret = fclose(stream);
+	} while (false);
+	return ret;
 }
 
 
-int PS4API scec_feof(void)
+int PS4API scec_feof(FILE * stream)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	LOG_SCE_TRACE("fp %p", stream);
+	return feof(stream);
 }
 
 
-int PS4API scec_fgetc(void)
+int PS4API scec_fgetc(FILE * stream)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	LOG_SCE_TRACE("fp %p", stream);
+	return fgetc(stream);
 }
 
 
@@ -85,17 +101,15 @@ int PS4API scec_fputs(void)
 
 int PS4API scec_setvbuf(FILE *stream, char *buf, int mode, size_t size)
 {
-	//LOG_SCE_TRACE("file %p buff %p mode %x size %x", stream, buf, mode, size);
-	//return setvbuf(stream, buf, mode, size);
-	LOG_SCE_DUMMY_IMPL();
-	return 0;
+	LOG_SCE_TRACE("file %p buff %p mode %x size %x", stream, buf, mode, size);
+	return setvbuf(stream, buf, mode, size);
 }
 
 
-int PS4API scec_ferror(void)
+int PS4API scec_ferror(FILE* stream)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	LOG_SCE_TRACE("fp %p", stream);
+	return ferror(stream);
 }
 
 
@@ -106,15 +120,14 @@ int PS4API scec_fflush(void)
 }
 
 
-int PS4API scec_fgets(void)
+char* PS4API scec_fgets(char * str, int num, FILE * stream)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	return fgets(str, num, stream);
 }
 
 
-int PS4API scec_freopen(void)
+FILE* PS4API scec_freopen(const char * filename, const char * mode, FILE * stream)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	LOG_SCE_TRACE("filename %s, mode %s, fp %p", filename, mode, stream );
+	return freopen(filename, mode, stream);
 }

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel.cpp
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel.cpp
@@ -51,10 +51,9 @@ int PS4API _sceKernelSetThreadAtexitReport()
 	return SCE_OK;
 }
 
-int PS4API sceKernelClockGettime(void)
+int PS4API sceKernelClockGettime(sce_clockid_t clk_id, struct sce_timespec * tp)
 {
-	LOG_FIXME("Not implemented");
-	return SCE_OK;
+	return scek_clock_gettime(clk_id, tp);
 }
 
 int PS4API sceKernelGetCpumode(void)

--- a/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
+++ b/GPCS4/SceModules/SceLibkernel/sce_libkernel.h
@@ -66,7 +66,7 @@ void *PS4API sceKernelGetProcParam(uint64_t p1, uint64_t p2);
 int PS4API sceKernelAllocateDirectMemory(sce_off_t searchStart, sce_off_t searchEnd, size_t len, size_t alignment, int memoryType, sce_off_t *physAddrOut);
 
 
-int PS4API sceKernelClockGettime(void);
+int PS4API sceKernelClockGettime(sce_clockid_t clk_id, struct sce_timespec * tp);
 
 
 int PS4API sceKernelClose(int d);

--- a/GPCS4/SceModules/SceNpScore/sce_npscore.cpp
+++ b/GPCS4/SceModules/SceNpScore/sce_npscore.cpp
@@ -18,6 +18,13 @@ int PS4API sceNpScoreCreateNpTitleCtx(void)
 }
 
 
+int PS4API sceNpScoreCreateNpTitleCtxA(void)
+{
+	LOG_SCE_DUMMY_IMPL();
+	return 1;
+}
+
+
 int PS4API sceNpScoreCreateRequest(void)
 {
 	LOG_FIXME("Not implemented");

--- a/GPCS4/SceModules/SceNpScore/sce_npscore.h
+++ b/GPCS4/SceModules/SceNpScore/sce_npscore.h
@@ -28,6 +28,9 @@ extern const SCE_EXPORT_MODULE g_ExpModuleSceNpScore;
 int PS4API sceNpScoreCreateNpTitleCtx(void);
 
 
+int PS4API sceNpScoreCreateNpTitleCtxA(void);
+
+
 int PS4API sceNpScoreCreateRequest(void);
 
 

--- a/GPCS4/SceModules/SceNpScore/sce_npscore_export.cpp
+++ b/GPCS4/SceModules/SceNpScore/sce_npscore_export.cpp
@@ -9,6 +9,7 @@
 static const SCE_EXPORT_FUNCTION g_pSceNpScore_libSceNpScore_FunctionTable[] =
 {
 	{ 0x2A7340D53120B412, "sceNpScoreCreateNpTitleCtx", (void*)sceNpScoreCreateNpTitleCtx },
+	{ 0x1969d640d5d91f93, "sceNpScoreCreateNpTitleCtxA", (void*)sceNpScoreCreateNpTitleCtxA },
 	{ 0x816F2ACA362B51B9, "sceNpScoreCreateRequest", (void*)sceNpScoreCreateRequest },
 	{ 0x1B4A44F91342C1F9, "sceNpScoreDeleteNpTitleCtx", (void*)sceNpScoreDeleteNpTitleCtx },
 	{ 0x74AF3F4A061FEABE, "sceNpScoreDeleteRequest", (void*)sceNpScoreDeleteRequest },

--- a/GPCS4/SceModules/ScePad/sce_pad.cpp
+++ b/GPCS4/SceModules/ScePad/sce_pad.cpp
@@ -132,8 +132,18 @@ int PS4API scePadSetTiltCorrectionState(int32_t handle, bool bEnable)
 int PS4API scePadReadState(int32_t handle, ScePadData *pData)
 {
 	LOG_SCE_TRACE("handle %d", handle);
+	int err = SCE_PAD_ERROR_INVALID_HANDLE;
+	do 
+	{
+		auto& pad = g_padSlot[handle];
+		if (!pad)
+		{
+			break;
+		}
 
-	return g_padSlot[handle]->readState(pData);
+		err = g_padSlot[handle]->readState(pData);
+	} while (false);
+	return err;
 }
 
 

--- a/GPCS4/SceModules/SceSaveData/sce_savedata.cpp
+++ b/GPCS4/SceModules/SceSaveData/sce_savedata.cpp
@@ -40,6 +40,13 @@ int PS4API sceSaveDataInitialize3(void)
 }
 
 
+int PS4API sceSaveDataMount(void)
+{
+	LOG_FIXME("Not implemented");
+	return SCE_OK;
+}
+
+
 int PS4API sceSaveDataMount2(void)
 {
 	LOG_FIXME("Not implemented");

--- a/GPCS4/SceModules/SceSaveData/sce_savedata.h
+++ b/GPCS4/SceModules/SceSaveData/sce_savedata.h
@@ -64,6 +64,9 @@ int PS4API sceSaveDataDirNameSearch(void);
 int PS4API sceSaveDataGetParam(void);
 
 
+int PS4API sceSaveDataMount(void);
+
+
 int PS4API sceSaveDataMount2(void);
 
 

--- a/GPCS4/SceModules/SceSaveData/sce_savedata_export.cpp
+++ b/GPCS4/SceModules/SceSaveData/sce_savedata_export.cpp
@@ -12,6 +12,7 @@ static const SCE_EXPORT_FUNCTION g_pSceSaveData_libSceSaveData_FunctionTable[] =
 	{ 0x7722219D7ABFD123, "sceSaveDataDirNameSearch", (void*)sceSaveDataDirNameSearch },
 	{ 0x5E0BD2B88767325C, "sceSaveDataGetParam", (void*)sceSaveDataGetParam },
 	{ 0x4F2C2B14A0A82C66, "sceSaveDataInitialize3", (void*)sceSaveDataInitialize3 },
+	{ 0xdf61d0010770336a, "sceSaveDataMount", (void*)sceSaveDataMount },
 	{ 0xD33E393C81FE48D2, "sceSaveDataMount2", (void*)sceSaveDataMount2 },
 	{ 0x73CF18CB9E0CC74C, "sceSaveDataSaveIcon", (void*)sceSaveDataSaveIcon },
 	{ 0xF39CEE97FFDE197B, "sceSaveDataSetParam", (void*)sceSaveDataSetParam },

--- a/GPCS4/SceModules/SceSaveDataDialog/sce_savedatadialog.cpp
+++ b/GPCS4/SceModules/SceSaveDataDialog/sce_savedatadialog.cpp
@@ -39,5 +39,19 @@ int PS4API sceSaveDataDialogUpdateStatus(void)
 }
 
 
+int PS4API sceSaveDataDialogGetResult( void )
+{
+	LOG_FIXME("Not implemented");
+	return SCE_OK;
+}
+
+
+int PS4API sceSaveDataDialogProgressBarSetValue( void )
+{
+	LOG_FIXME("Not implemented");
+	return SCE_OK;
+}
+
+
 
 

--- a/GPCS4/SceModules/SceSaveDataDialog/sce_savedatadialog.h
+++ b/GPCS4/SceModules/SceSaveDataDialog/sce_savedatadialog.h
@@ -37,5 +37,8 @@ int PS4API sceSaveDataDialogTerminate(void);
 int PS4API sceSaveDataDialogUpdateStatus(void);
 
 
+int PS4API sceSaveDataDialogGetResult(void);
 
+
+int PS4API sceSaveDataDialogProgressBarSetValue(void);
 

--- a/GPCS4/SceModules/SceSaveDataDialog/sce_savedatadialog_export.cpp
+++ b/GPCS4/SceModules/SceSaveDataDialog/sce_savedatadialog_export.cpp
@@ -12,6 +12,8 @@ static const SCE_EXPORT_FUNCTION g_pSceSaveDataDialog_libSceSaveDataDialog_Funct
 	{ 0xE2D3E1B0FE85A432, "sceSaveDataDialogOpen", (void*)sceSaveDataDialogOpen },
 	{ 0x62E1F6140EDACEA4, "sceSaveDataDialogTerminate", (void*)sceSaveDataDialogTerminate },
 	{ 0x28ADC1760D5158AD, "sceSaveDataDialogUpdateStatus", (void*)sceSaveDataDialogUpdateStatus },
+	{ 0xc84889feaaabe828, "sceSaveDataDialogGetResult", (void*)sceSaveDataDialogGetResult },
+	{ 0x85acb509f4e62f20, "sceSaveDataDialogProgressBarSetValue", (void*)sceSaveDataDialogProgressBarSetValue },
 	SCE_FUNCTION_ENTRY_END
 };
 

--- a/GPCS4/SceModules/SceScreenShot/sce_screenshot.cpp
+++ b/GPCS4/SceModules/SceScreenShot/sce_screenshot.cpp
@@ -25,5 +25,12 @@ int PS4API sceScreenShotEnable(void)
 }
 
 
+int PS4API sceScreenShotSetOverlayImageWithOrigin( void )
+{
+	LOG_FIXME("Not implemented");
+	return SCE_OK;
+}
+
+
 
 

--- a/GPCS4/SceModules/SceScreenShot/sce_screenshot.h
+++ b/GPCS4/SceModules/SceScreenShot/sce_screenshot.h
@@ -31,5 +31,5 @@ int PS4API sceScreenShotDisable(void);
 int PS4API sceScreenShotEnable(void);
 
 
-
+int PS4API sceScreenShotSetOverlayImageWithOrigin(void);
 

--- a/GPCS4/SceModules/SceScreenShot/sce_screenshot_export.cpp
+++ b/GPCS4/SceModules/SceScreenShot/sce_screenshot_export.cpp
@@ -10,6 +10,7 @@ static const SCE_EXPORT_FUNCTION g_pSceScreenShot_libSceScreenShot_FunctionTable
 {
 	{ 0xB4861FD16E554E2F, "sceScreenShotDisable", (void*)sceScreenShotDisable },
 	{ 0xDB1C54B6E0BF4731, "sceScreenShotEnable", (void*)sceScreenShotEnable },
+	{ 0xef7590e098f49c92, "sceScreenShotSetOverlayImageWithOrigin", (void*)sceScreenShotSetOverlayImageWithOrigin },
 	SCE_FUNCTION_ENTRY_END
 };
 

--- a/GPCS4/SceModules/SceUserService/sce_userservice.cpp
+++ b/GPCS4/SceModules/SceUserService/sce_userservice.cpp
@@ -19,6 +19,13 @@ int PS4API sceUserServiceInitialize(const SceUserServiceInitializeParams *initPa
 }
 
 
+int PS4API sceUserServiceInitialize2( void )
+{
+	LOG_FIXME("Not implemented");
+	return SCE_OK;
+}
+
+
 int PS4API sceUserServiceTerminate(void)
 {
 	LOG_FIXME("Not implemented");

--- a/GPCS4/SceModules/SceUserService/sce_userservice.h
+++ b/GPCS4/SceModules/SceUserService/sce_userservice.h
@@ -33,6 +33,10 @@ int PS4API sceUserServiceGetInitialUser(SceUserServiceUserId *userId);
 
 int PS4API sceUserServiceInitialize(const SceUserServiceInitializeParams *initParams);
 
+
+int PS4API sceUserServiceInitialize2( void );
+
+
 int PS4API sceUserServiceGetLoginUserIdList(SceUserServiceLoginUserIdList* userIdList);
 
 

--- a/GPCS4/SceModules/SceUserService/sce_userservice_export.cpp
+++ b/GPCS4/SceModules/SceUserService/sce_userservice_export.cpp
@@ -14,6 +14,7 @@ static const SCE_EXPORT_FUNCTION g_pSceUserService_libSceUserService_FunctionTab
 	{ 0x6F01634BE6D7F660, "sceUserServiceTerminate", (void*)sceUserServiceTerminate },
 	{ 0xD71C5C3221AED9FA, "sceUserServiceGetUserName", (void*)sceUserServiceGetUserName },
 	{ 0x7CF87298A36F2BF0, "sceUserServiceGetLoginUserIdList", (void*)sceUserServiceGetLoginUserIdList },
+	{ 0x6b3ff447a7af899d, "sceUserServiceInitialize2", (void*)sceUserServiceInitialize2 },
 	SCE_FUNCTION_ENTRY_END
 };
 

--- a/GPCS4/SceModules/SceVideoOut/sce_videoout.cpp
+++ b/GPCS4/SceModules/SceVideoOut/sce_videoout.cpp
@@ -279,3 +279,10 @@ int PS4API sceVideoOutWaitVblank(void)
 	return SCE_OK;
 }
 
+
+int PS4API sceVideoOutGetVblankStatus( void )
+{
+	LOG_SCE_GRAPHIC("Not implemented");
+	return SCE_OK;
+}
+

--- a/GPCS4/SceModules/SceVideoOut/sce_videoout.h
+++ b/GPCS4/SceModules/SceVideoOut/sce_videoout.h
@@ -85,3 +85,6 @@ int PS4API sceVideoOutSubmitFlip(void);
 
 int PS4API sceVideoOutWaitVblank(void);
 
+
+int PS4API sceVideoOutGetVblankStatus(void);
+

--- a/GPCS4/SceModules/SceVideoOut/sce_videoout_export.cpp
+++ b/GPCS4/SceModules/SceVideoOut/sce_videoout_export.cpp
@@ -28,6 +28,7 @@ static const SCE_EXPORT_FUNCTION g_pSceVideoOut_libSceVideoOut_FunctionTable[] =
 	{ 0x20E7601E508653F9, "sceVideoOutSubmitChangeBufferAttribute", (void*)sceVideoOutSubmitChangeBufferAttribute },
 	{ 0x538E8DC0E889A72B, "sceVideoOutSubmitFlip", (void*)sceVideoOutSubmitFlip },
 	{ 0x8FA45A01495A2EFD, "sceVideoOutWaitVblank", (void*)sceVideoOutWaitVblank },
+	{ 0xd456412b2f0778d5, "sceVideoOutGetVblankStatus", (void*)sceVideoOutGetVblankStatus },
 	SCE_FUNCTION_ENTRY_END
 };
 


### PR DESCRIPTION
Sonic Mania will boot to title screen and send graphics commands. It will crash with a graphics problem but if GPCS4_NO_GRAPHICS is defined then it will tick over and keep sending whilst music is playing.