### PR TITLE
Spinlock bug fixes & performance improvement

### DIFF
--- a/GPCS4/Util/UtilSync.h
+++ b/GPCS4/Util/UtilSync.h
@@ -12,6 +12,7 @@
  * in case the structure is not likely contested.
  */
 
+// detect x86
 #ifdef _M_X64
 #define __UTIL_SYNC_X86__ 1
 #elif _M_IX86
@@ -20,20 +21,27 @@
 #define __UTIL_SYNC_X86__ 1
 #elif __i386
 #define __UTIL_SYNC_X86__ 1
+#else
+// none of the above
+#define __UTIL_SYNC_UNKNOWN_ARCH__ 1
+#endif
+
+#ifdef __UTIL_SYNC_UNKNOWN_ARCH__
+#error "unsupported platform"
 #endif
 
 #ifdef __UTIL_SYNC_X86__
-void pause() {
-    //https://software.intel.com/content/www/us/en/develop/articles/benefitting-power-and-performance-sleep-loops.html
-    //https://www.felixcloutier.com/x86/pause
+//https://software.intel.com/content/www/us/en/develop/articles/benefitting-power-and-performance-sleep-loops.html
+//https://www.felixcloutier.com/x86/pause
 #ifdef _MSC_VER
-    __asm pause
-#else
-    asm volatile("pause");
+#include <intrin.h>
 #endif
-}
-#else
 void pause() {
+#ifdef _MSC_VER
+    _mm_pause();
+#else
+    __builtin_ia32_pause();
+#endif
 }
 #endif
 

--- a/GPCS4/Util/UtilSync.h
+++ b/GPCS4/Util/UtilSync.h
@@ -11,38 +11,55 @@
  * protect data structures for a short duration
  * in case the structure is not likely contested.
  */
-class Spinlock 
-{
+
+#ifdef _M_X64
+#define __UTIL_SYNC_X86__ 1
+#elif _M_IX86
+#define __UTIL_SYNC_X86__ 1
+#elif __x86_64
+#define __UTIL_SYNC_X86__ 1
+#elif __i386
+#define __UTIL_SYNC_X86__ 1
+#endif
+
+#ifdef __UTIL_SYNC_X86__
+void pause() {
+    //https://software.intel.com/content/www/us/en/develop/articles/benefitting-power-and-performance-sleep-loops.html
+    //https://www.felixcloutier.com/x86/pause
+#ifdef _MSC_VER
+    __asm pause
+#else
+    asm volatile("pause");
+#endif
+}
+#else
+void pause() {
+}
+#endif
+
+class Spinlock {
 
 public:
+    Spinlock() = default;
+    Spinlock(const Spinlock &) = delete;
+    Spinlock &operator=(const Spinlock &) = delete;
 
-	Spinlock() { }
-	~Spinlock() { }
+    void lock() {
+        uint32_t expected;
+        while (!m_lock.compare_exchange_weak(expected = 0, 1, std::memory_order_release, std::memory_order_consume)) {
+            pause();
+        }
+    }
 
-	Spinlock(const Spinlock&) = delete;
-	Spinlock& operator = (const Spinlock&) = delete;
+    void unlock() {
+        m_lock.store(0, std::memory_order_release);
+    }
 
-	void lock() 
-	{
-		while (!this->try_lock())
-		{
-			std::this_thread::yield();
-		}
-			
-	}
-
-	void unlock() 
-	{
-		m_lock.store(0, std::memory_order_release);
-	}
-
-	bool try_lock() 
-	{
-		return !m_lock.load() && !m_lock.exchange(1, std::memory_order_acquire);
-	}
+    bool try_lock() {
+        uint32_t expected = 0;
+        return m_lock.compare_exchange_strong(expected, 1, std::memory_order_release, std::memory_order_consume);
+    }
 
 private:
-
-	std::atomic<uint32_t> m_lock = { 0 };
-
+    std::atomic<uint32_t> m_lock = {0};
 };

--- a/GPCS4/Util/UtilSync.h
+++ b/GPCS4/Util/UtilSync.h
@@ -61,5 +61,5 @@ public:
     }
 
 private:
-    std::atomic<uint32_t> m_lock = {0};
+    std::atomic<uint32_t> m_lock{};
 };


### PR DESCRIPTION
Dear Maintainer,
Greeting!

I am really impressed by your project, I think this might be one of the earliest PS4 emulators out there, and looks like it is been well developed.
I just spotted a race condition bug and an opportunity for further performance gain in the Spinlock(UtilSync.h), so here I have a patch for that.

**1. The race condition bug**
It is located in function "try_lock":

`
return !m_lock.load() && !m_lock.exchange(1, std::memory_order_acquire);
`

Despite the "m_lock.exchange" and "m_lock.load" themselves are atomic operations, the combination of them is not. This is the so-called "load-modify-store" operation, the best practice of this is to use built-in CAS functions, this provides overall atomicity for these two operations:

`
uint32_t expected = 0;
`
`
return m_lock.compare_exchange_strong(expected, 1, std::memory_order_release, std::memory_order_consume);
`

please read here for more information:
https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange

**2. Performance improvement**
The previous spin loop in "lock" function was:

`
while (!this->try_lock())
{
    std::this_thread::yield();
}
`

That means while we are trying to "lock" it, the current thread will always be scheduled out by the OS which is not a good thing to do for a spinlock since this will harm performance badly. (check https://www.realworldtech.com/forum/?threadid=189711&curpostid=189723 for more detail)

Instead, as Intel engineer suggested(https://software.intel.com/content/www/us/en/develop/articles/benefitting-power-and-performance-sleep-loops.html), we should use the x86 "pause" instruction for this purpose:
`
void pause() {
    asm volatile("pause");
}
`
`
uint32_t expected;
`
`
while (!m_lock.compare_exchange_weak(expected = 0, 1, std::memory_order_release, std::memory_order_consume)) {
    pause();
}
`
Also, you might notice that I'm using "compare_exchange_weak" but not "compare_exchange_strong' in the loop, this is due to the characteristical of "compare_exchange_weak", it's been said that the weak version will yield better performance on some platforms.(again, referencing https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange)

I would like to thank you for creating such an amazing project, and I'm looking forward to your reply:)
